### PR TITLE
Changed JDK for Travis so that owltools will run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk7
+  - oraclejdk8
 
 before_script:
   - mkdir -p bin


### PR DESCRIPTION
I think the owltools version being downloaded was built with Java 8. The travis file was specifying JDK 7, so it was failing to run.