### PR TITLE
add synonym to unserrated

### DIFF
--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -13939,6 +13939,7 @@ id: PATO:0001975
 name: unserrated
 def: "A surface feature shape quality inhering in a bearer by virtue of the bearer's lacking sharp straight-edged teeth pointing to the apex." [ISBN:0881923214]
 subset: value_slim
+synonym: "smooth" RELATED []
 is_a: PATO:0001976 ! serration
 relationship: is_opposite_of PATO:0001206 ! serrated
 


### PR DESCRIPTION
closes #299

@matentzn is it okay to have a related synonym that is the same as another term label? (there is a 'smooth' class in PATO)