### PR TITLE
Removing quotation marks from Martinotti subclasses

### DIFF
--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -21922,15 +21922,17 @@ created_by: http://orcid.org/0000-0001-7258-9596
 
 [Term]
 id: PATO:0070008
-name: 'T-shaped' Martinotti morphology
+name: T Martinotti morphology
 def: "A Martinotti cell morphology that inheres in neurons which have axons that form a horizontal ramification, making it T-shaped." [doi:10.1016/b978-0-12-369497-3.10004-4]
+synonym: "'T-shaped' Martinotti morphology" EXACT []
 is_a: PATO:0070007 ! Martinotti morphology
 created_by: http://orcid.org/0000-0001-7258-9596
 
 [Term]
 id: PATO:0070009
-name: 'fanning-out' Martinotti morphology
+name: fan Martinotti morphology
 def: "A Martinotti cell morphology that inheres in neurons which have axons that form a fan-like plexus." [doi:10.1016/b978-0-12-369497-3.10004-4]
+synonym: "'fanning-out' Martinotti morphology" EXACT []
 is_a: PATO:0070007 ! Martinotti morphology
 created_by: http://orcid.org/0000-0001-7258-9596
 


### PR DESCRIPTION
Currently Martinotti morphology subclasses have quotation marks in their names making them difficult to use.

Moved Martinotti subclass names with quotation marks to synonyms and changed names to ones without.