### PR TITLE
Fixing anterior and ventral synonyms

### DIFF
--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -7358,7 +7358,6 @@ def: "A spatial quality inhering in a bearer by virtue of the bearer's being loc
 subset: mpath_slim
 subset: relational_slim
 subset: value_slim
-synonym: "anterior_ to" EXACT []
 is_a: PATO:0000140 ! position
 
 [Term]
@@ -10899,7 +10898,6 @@ subset: mpath_slim
 subset: relational_slim
 subset: value_slim
 synonym: "preceding" EXACT []
-synonym: "ventral_to" EXACT []
 is_a: PATO:0000140 ! position
 
 [Term]


### PR DESCRIPTION
Fixes #351
Not sure why there is a need for synonyms with an underscore in it? Happy to add it back correctly if there is a real need.