### PR TITLE
remove term editor from illegal-annotation

### DIFF
--- a/src/sparql/illegal-annotation-property-violation.sparql
+++ b/src/sparql/illegal-annotation-property-violation.sparql
@@ -49,7 +49,6 @@ SELECT DISTINCT ?annotation WHERE {
     <http://purl.obolibrary.org/obo/UBPROP_0000112>,
     <http://purl.obolibrary.org/obo/UBPROP_0000201>,
     <http://purl.obolibrary.org/obo/UBPROP_0000202>,
-    <http://purl.obolibrary.org/obo/term_editor>,
     <http://purl.org/dc/elements/1.1/date>,
     <http://purl.org/dc/elements/1.1/description>,
     <http://purl.org/dc/terms/contributor>,


### PR DESCRIPTION
<http://purl.obolibrary.org/obo/term_editor>, should not exist, but is in https://github.com/pato-ontology/pato/blob/master/src/sparql/illegal-annotation-property-violation.sparql