### PR TITLE
Reserve PATO ID range for Mark Andrew Miller (idrange:25)

### DIFF
--- a/src/ontology/pato-idranges.owl
+++ b/src/ontology/pato-idranges.owl
@@ -117,3 +117,7 @@ EquivalentTo: xsd:integer[> 103000 , <= 103200]
 Datatype: idrange:24
 Annotations: allocatedto: "Kalliope Panoutsopoulou"
 EquivalentTo: xsd:integer[> 103200 , <= 103300]
+
+Datatype: idrange:25
+Annotations: allocatedto: "Mark Andrew Miller"
+EquivalentTo: xsd:integer[> 103300 , <= 104000]


### PR DESCRIPTION
Reserves PATO ID range idrange:25 (103301-104000) allocated to Mark Andrew Miller, so NMDC/GOLD-driven term additions can mint stable identifiers. Mirrors the allocation in #557.

Nothing currently uses IDs in this block (highest minted is PATO:0103006).

A companion PR adding ploidy subclasses (closes #605) depends on this range.