### PR TITLE
Add octoploid and allopolyploidy subclasses to ploidy hierarchy

### DIFF
--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -22660,6 +22660,35 @@ intersection_of: RO:0015007 PATO:0000461 ! increased in magnitude relative to no
 property_value: http://purl.org/dc/elements/1.1/date "2025-04-10T16:37:33Z" xsd:dateTime
 property_value: http://www.geneontology.org/formats/oboInOwl#http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-8314-2140
 
+[Term]
+id: PATO:0103301
+name: octoploid
+def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing eight homologous sets of chromosomes." [Wikipedia:https\://en.wikipedia.org/wiki/Polyploidy]
+synonym: "octaploid" EXACT []
+is_a: PATO:0001377 ! polyploid
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
+
+[Term]
+id: PATO:0103302
+name: allotetraploid
+def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing four homologous sets of chromosomes derived from two or more different species." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+is_a: PATO:0001379 ! allopolyploidy
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
+
+[Term]
+id: PATO:0103303
+name: allohexaploid
+def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing six homologous sets of chromosomes derived from two or more different species." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+is_a: PATO:0001379 ! allopolyploidy
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
+
+[Term]
+id: PATO:0103304
+name: segmental allotetraploid
+def: "An allotetraploid quality inhering in a bearer by virtue of the bearer's two chromosome sets being only partially differentiated (partially homeologous)." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+is_a: PATO:0103302 ! allotetraploid
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
+
 [Typedef]
 id: correlates_with
 name: obsolete correlates_with

--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -22698,7 +22698,7 @@ creation_date: 2026-06-17T22:04:36Z
 id: PATO:0103304
 name: segmental allotetraploid
 def: "An allotetraploid quality inhering in a bearer by virtue of the bearer's two parental subgenomes being only partially differentiated (partially homeologous)." [PMID:33005183, PMID:29985538]
-comment: Intermediate between autopolyploidy and allopolyploidy; the two parental subgenomes are partially homeologous, producing inconsistent chromosome pairing. Cultivated peanut (Arachis hypogaea) is an example.
+comment: The two parental subgenomes are partially homeologous, producing inconsistent chromosome pairing. Cultivated peanut (Arachis hypogaea) is an example.
 subset: cell_quality
 subset: value_slim
 is_a: PATO:0103302 ! allotetraploid

--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -22663,7 +22663,7 @@ property_value: http://www.geneontology.org/formats/oboInOwl#http://purl.org/dc/
 [Term]
 id: PATO:0103301
 name: octoploid
-def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing eight homologous sets of chromosomes." []
+def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing eight homologous sets of chromosomes." [Wikipedia:http\://en.wikipedia.org/wiki/Octoploid]
 comment: Cultivated strawberry is octoploid (2n=8x=56).
 subset: cell_quality
 subset: value_slim

--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -22670,6 +22670,7 @@ subset: value_slim
 synonym: "octaploid" EXACT []
 is_a: PATO:0001377 ! polyploid
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
+creation_date: 2026-06-17T22:04:36Z
 
 [Term]
 id: PATO:0103302
@@ -22680,6 +22681,7 @@ subset: cell_quality
 subset: value_slim
 is_a: PATO:0001379 ! allopolyploidy
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
+creation_date: 2026-06-17T22:04:36Z
 
 [Term]
 id: PATO:0103303
@@ -22690,6 +22692,7 @@ subset: cell_quality
 subset: value_slim
 is_a: PATO:0001379 ! allopolyploidy
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
+creation_date: 2026-06-17T22:04:36Z
 
 [Term]
 id: PATO:0103304
@@ -22700,6 +22703,7 @@ subset: cell_quality
 subset: value_slim
 is_a: PATO:0103302 ! allotetraploid
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
+creation_date: 2026-06-17T22:04:36Z
 
 [Typedef]
 id: correlates_with

--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -22663,7 +22663,8 @@ property_value: http://www.geneontology.org/formats/oboInOwl#http://purl.org/dc/
 [Term]
 id: PATO:0103301
 name: octoploid
-def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing eight homologous sets of chromosomes." [Wikipedia:https\://en.wikipedia.org/wiki/Polyploidy]
+def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing eight homologous sets of chromosomes." []
+comment: Cultivated strawberry is octoploid (2n=8x=56).
 subset: cell_quality
 subset: value_slim
 synonym: "octaploid" EXACT []
@@ -22673,7 +22674,8 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001
 [Term]
 id: PATO:0103302
 name: allotetraploid
-def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing four homologous sets of chromosomes derived from two or more different species." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing four sets of chromosomes derived from two or more different species." []
+comment: Examples include cotton and quinoa.
 subset: cell_quality
 subset: value_slim
 is_a: PATO:0001379 ! allopolyploidy
@@ -22682,7 +22684,8 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001
 [Term]
 id: PATO:0103303
 name: allohexaploid
-def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing six homologous sets of chromosomes derived from two or more different species." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing six sets of chromosomes derived from two or more different species." []
+comment: Examples include bread wheat (Triticum aestivum) and triticale.
 subset: cell_quality
 subset: value_slim
 is_a: PATO:0001379 ! allopolyploidy
@@ -22691,7 +22694,8 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001
 [Term]
 id: PATO:0103304
 name: segmental allotetraploid
-def: "An allotetraploid quality inhering in a bearer by virtue of the bearer's two chromosome sets being only partially differentiated (partially homeologous)." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+def: "An allotetraploid quality inhering in a bearer by virtue of the bearer's two parental subgenomes being only partially differentiated (partially homeologous)." [PMID:33005183, PMID:29985538]
+comment: Intermediate between autopolyploidy and allopolyploidy; the two parental subgenomes are partially homeologous, producing inconsistent chromosome pairing. Cultivated peanut (Arachis hypogaea) is an example.
 subset: cell_quality
 subset: value_slim
 is_a: PATO:0103302 ! allotetraploid

--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -22680,6 +22680,7 @@ comment: Examples include cotton and quinoa.
 subset: cell_quality
 subset: value_slim
 is_a: PATO:0001379 ! allopolyploidy
+is_a: PATO:0001382 ! tetraploid
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
 creation_date: 2026-06-17T22:04:36Z
 
@@ -22691,6 +22692,7 @@ comment: Examples include bread wheat (Triticum aestivum) and triticale.
 subset: cell_quality
 subset: value_slim
 is_a: PATO:0001379 ! allopolyploidy
+is_a: PATO:0001384 ! hexaploid
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
 creation_date: 2026-06-17T22:04:36Z
 

--- a/src/ontology/pato-edit.obo
+++ b/src/ontology/pato-edit.obo
@@ -22664,6 +22664,8 @@ property_value: http://www.geneontology.org/formats/oboInOwl#http://purl.org/dc/
 id: PATO:0103301
 name: octoploid
 def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing eight homologous sets of chromosomes." [Wikipedia:https\://en.wikipedia.org/wiki/Polyploidy]
+subset: cell_quality
+subset: value_slim
 synonym: "octaploid" EXACT []
 is_a: PATO:0001377 ! polyploid
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
@@ -22672,6 +22674,8 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001
 id: PATO:0103302
 name: allotetraploid
 def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing four homologous sets of chromosomes derived from two or more different species." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+subset: cell_quality
+subset: value_slim
 is_a: PATO:0001379 ! allopolyploidy
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
 
@@ -22679,6 +22683,8 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001
 id: PATO:0103303
 name: allohexaploid
 def: "A polyploidy quality inhering in a bearer by virtue of the bearer's containing six homologous sets of chromosomes derived from two or more different species." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+subset: cell_quality
+subset: value_slim
 is_a: PATO:0001379 ! allopolyploidy
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
 
@@ -22686,6 +22692,8 @@ property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001
 id: PATO:0103304
 name: segmental allotetraploid
 def: "An allotetraploid quality inhering in a bearer by virtue of the bearer's two chromosome sets being only partially differentiated (partially homeologous)." [Wikipedia:https\://en.wikipedia.org/wiki/Allopolyploidy]
+subset: cell_quality
+subset: value_slim
 is_a: PATO:0103302 ! allotetraploid
 property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0001-9076-6066
 


### PR DESCRIPTION
Adds four polyploidy subclasses under PATO:0001374 ploidy that recur in GOLD (`dw_sample_taxonomy_info.ploidy_comments`) and are not covered by existing subclasses:

| label | parent | GOLD evidence |
|---|---|---|
| octoploid | polyploid (PATO:0001377) | "Tetraploid or Octoploid" (168), "octaploid" variants |
| allotetraploid | allopolyploidy (PATO:0001379) | "Allotetraploid" (105) |
| allohexaploid | allopolyploidy (PATO:0001379) | "allohexaploid" (10) |
| segmental allotetraploid | allotetraploid (new) | "segmental allotetraploid" (96) |

IDs 0103301-0103304 come from idrange:25, reserved in 
- #606. 

Closes #605.